### PR TITLE
Recognising characters of the form \x, \xN and\xNN

### DIFF
--- a/src/regex.rs
+++ b/src/regex.rs
@@ -217,6 +217,30 @@ impl<I: Iterator<Item=char>> Parser<I> {
                     Some('r') => Ok('\r'),
                     Some('n') => Ok('\n'),
                     Some('t') => Ok('\t'),
+                    Some('f') => Ok('\x0c'),
+                    Some('x') => {
+                        macro_rules! follow_num {
+                            () => {
+                                match self.it.peek() {
+                                    Some(c) => c.to_digit(16),
+                                    _ => None
+                                }
+                            }
+                        }
+                        match follow_num!() {
+                            Some(n1) => {
+                                self.it.next();
+                                match follow_num!() {
+                                    Some(n2) => {
+                                        self.it.next();
+                                        Ok(char::from_u32(n1 * 16 + n2).unwrap())
+                                    },
+                                    None => Ok(char::from_u32(n1).unwrap()),
+                                }
+                            }
+                            None => Ok('\x00')
+                        }
+                    },
                     Some(c) => Ok(c),
                     None => Err(ParseError::UnexpectedEof("unfollowed '\\'"))
                 }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -7,6 +7,27 @@ use std::collections::BTreeMap;
 fn test_regex_parse() {
     assert_eq!("".parse::<Regex<char>>().unwrap().normalize(), Empty);
     assert_eq!("a".parse::<Regex<char>>().unwrap().normalize(), Alt(vec!['a'], vec![]));
+    assert_eq!(
+        "\\x".parse::<Regex<char>>().unwrap().normalize(),
+        Alt(vec!['\x00'], vec![])
+    );
+    assert_eq!(
+        "\\xc".parse::<Regex<char>>().unwrap().normalize(),
+        Alt(vec!['\x0c'], vec![])
+    );
+    assert_eq!(
+        "\\x0C".parse::<Regex<char>>().unwrap().normalize(),
+        Alt(vec!['\x0c'], vec![])
+    );
+    assert_eq!(
+        "\\xFF".parse::<Regex<char>>().unwrap().normalize(),
+        Alt(vec!['\u{00ff}'], vec![])
+    );
+    assert_eq!(
+        "\\x123".parse::<Regex<char>>().unwrap().normalize(),
+        Cat(vec![Alt(vec!['\x12'], vec![]),
+                 Alt(vec!['3'], vec![])]
+    ));
     assert_eq!("abc".parse::<Regex<char>>().unwrap().normalize(),
         Cat(vec![Alt(vec!['a'], vec![]),
                  Alt(vec!['b'], vec![]),


### PR DESCRIPTION
\xNN form can be used to encode any character in the range 0x0-0xFF. Also added recognition for a formfeed character (\f).